### PR TITLE
Update citationjs core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "standard": "^17.0.0"
   },
   "peerDependencies": {
-    "@citation-js/core": ">=0.5.1 <=0.8"
+    "@citation-js/core": ">=0.5.1 <0.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "standard": "^17.0.0"
   },
   "peerDependencies": {
-    "@citation-js/core": ">=0.5.1 <=0.6"
+    "@citation-js/core": ">=0.5.1 <=0.8"
   }
 }


### PR DESCRIPTION
Hi!

Just wanted to start by saying thanks for the plugin, it's been a lifesaver.

I noticed the strict versioning for @citation-js/core is causing some peer dependency warnings since v0.7 is out. I ran some tests on both v0.6 and v0.7.21 and everything seems to work smoothly.

Could we update the dependencies to allow both 0.6.x and 0.7.x? It would help keep the console clean and stop people from worrying about the compatibility issues brought up in #3.